### PR TITLE
Dark Mode

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation project(':capacitor-share')
     implementation project(':capacitor-splash-screen')
     implementation project(':capacitor-status-bar')
+    implementation project(':robingenz-capacitor-android-dark-mode-support')
     implementation "androidx.legacy:legacy-support-v4:1.+"
     implementation "androidx.appcompat:appcompat:1.+"
 }

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -42,5 +42,9 @@
 	{
 		"pkg": "@capacitor/status-bar",
 		"classpath": "com.capacitorjs.plugins.statusbar.StatusBarPlugin"
+	},
+	{
+		"pkg": "@robingenz/capacitor-android-dark-mode-support",
+		"classpath": "dev.robingenz.capacitor.androiddarkmodesupport.AndroidDarkModeSupportPlugin"
 	}
 ]

--- a/android/app/src/main/java/it/airgap/wallet/MainActivity.java
+++ b/android/app/src/main/java/it/airgap/wallet/MainActivity.java
@@ -1,6 +1,8 @@
 package it.airgap.wallet;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
+import android.webkit.WebSettings;
 
 import com.getcapacitor.BridgeActivity;
 import com.getcapacitor.Plugin;

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -34,3 +34,6 @@ project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capa
 
 include ':capacitor-status-bar'
 project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
+
+include ':robingenz-capacitor-android-dark-mode-support'
+project(':robingenz-capacitor-android-dark-mode-support').projectDir = new File('../node_modules/@robingenz/capacitor-android-dark-mode-support/android')

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -80,8 +80,6 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "airgap-wallet",
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
@@ -58,6 +59,7 @@
         "@ngx-translate/core": "^13.0.0",
         "@ngx-translate/http-loader": "^6.0.0",
         "@obsidiansystems/hw-app-xtz": "^4.72.3",
+        "@robingenz/capacitor-android-dark-mode-support": "^1.0.1",
         "@sentry/browser": "6.2.5",
         "@taquito/taquito": "^10.0.0",
         "@types/ledgerhq__hw-transport": "^4.21.2",
@@ -784,7 +786,6 @@
     },
     "node_modules/@angular/compiler": {
       "version": "11.2.14",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -3819,6 +3820,14 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "node_modules/@robingenz/capacitor-android-dark-mode-support": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@robingenz/capacitor-android-dark-mode-support/-/capacitor-android-dark-mode-support-1.0.1.tgz",
+      "integrity": "sha512-JayMLgSy/ZraS7ckSb1McBxFavUy25A334TZ6Xnd9FCEmhP6+0+WoZpSAlNPtl1EZbt/elKv13qxMhGCJmUZtw==",
+      "peerDependencies": {
+        "@capacitor/core": "^3.0.0"
+      }
+    },
     "node_modules/@schematics/angular": {
       "version": "11.2.14",
       "dev": true,
@@ -4452,7 +4461,6 @@
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/helper-module-context": "1.9.0",
@@ -4462,22 +4470,18 @@
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-code-frame": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/wast-printer": "1.9.0"
@@ -4485,12 +4489,10 @@
     },
     "node_modules/@webassemblyjs/helper-fsm": {
       "version": "1.9.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@webassemblyjs/helper-module-context": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0"
@@ -4498,12 +4500,10 @@
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
@@ -4514,7 +4514,6 @@
     },
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
@@ -4522,7 +4521,6 @@
     },
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xtuc/long": "4.2.2"
@@ -4530,12 +4528,10 @@
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
@@ -4550,7 +4546,6 @@
     },
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
@@ -4562,7 +4557,6 @@
     },
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
@@ -4573,7 +4567,6 @@
     },
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
@@ -4586,7 +4579,6 @@
     },
     "node_modules/@webassemblyjs/wast-parser": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
@@ -4599,7 +4591,6 @@
     },
     "node_modules/@webassemblyjs/wast-printer": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
@@ -4609,12 +4600,10 @@
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -4766,7 +4755,6 @@
     },
     "node_modules/acorn": {
       "version": "6.4.2",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4866,7 +4854,6 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -4881,7 +4868,6 @@
     },
     "node_modules/ajv-errors": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ajv": ">=5.0.0"
@@ -4889,7 +4875,6 @@
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
@@ -5057,7 +5042,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -5077,7 +5062,6 @@
     },
     "node_modules/aproba": {
       "version": "1.2.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/arch": {
@@ -5193,7 +5177,6 @@
     },
     "node_modules/arr-diff": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5201,7 +5184,6 @@
     },
     "node_modules/arr-flatten": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5209,7 +5191,6 @@
     },
     "node_modules/arr-union": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5246,7 +5227,6 @@
     },
     "node_modules/array-unique": {
       "version": "0.3.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5270,7 +5250,6 @@
     },
     "node_modules/asn1.js": {
       "version": "5.4.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.0.0",
@@ -5281,7 +5260,6 @@
     },
     "node_modules/asn1.js/node_modules/bn.js": {
       "version": "4.12.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/assert": {
@@ -5304,7 +5282,6 @@
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5344,7 +5321,7 @@
     },
     "node_modules/async-each": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/async-limiter": {
@@ -5366,7 +5343,6 @@
     },
     "node_modules/atob": {
       "version": "2.1.2",
-      "dev": true,
       "license": "(MIT OR Apache-2.0)",
       "bin": {
         "atob": "bin/atob.js"
@@ -5491,12 +5467,10 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base": {
       "version": "0.11.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cache-base": "^1.0.1",
@@ -5520,7 +5494,6 @@
     },
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -5531,7 +5504,6 @@
     },
     "node_modules/base/node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
@@ -5542,7 +5514,6 @@
     },
     "node_modules/base/node_modules/is-data-descriptor": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
@@ -5553,7 +5524,6 @@
     },
     "node_modules/base/node_modules/is-descriptor": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^1.0.0",
@@ -5642,7 +5612,6 @@
     },
     "node_modules/big.js": {
       "version": "5.2.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -5657,7 +5626,7 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5785,7 +5754,6 @@
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bn.js": {
@@ -5869,7 +5837,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5989,7 +5956,6 @@
     },
     "node_modules/browserify-cipher": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserify-aes": "^1.0.4",
@@ -5999,7 +5965,6 @@
     },
     "node_modules/browserify-des": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.1",
@@ -6010,7 +5975,6 @@
     },
     "node_modules/browserify-rsa": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "^5.0.0",
@@ -6019,7 +5983,6 @@
     },
     "node_modules/browserify-sign": {
       "version": "4.2.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "bn.js": "^5.1.1",
@@ -6035,7 +5998,6 @@
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pako": "~1.0.5"
@@ -6331,7 +6293,6 @@
     },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/builtins": {
@@ -6387,7 +6348,6 @@
     },
     "node_modules/cache-base": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "collection-visit": "^1.0.0",
@@ -6657,7 +6617,7 @@
     },
     "node_modules/chokidar": {
       "version": "3.5.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -6685,7 +6645,6 @@
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
@@ -6712,7 +6671,6 @@
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "arr-union": "^3.1.0",
@@ -6726,7 +6684,6 @@
     },
     "node_modules/class-utils/node_modules/define-property": {
       "version": "0.2.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -7002,7 +6959,6 @@
     },
     "node_modules/collection-visit": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "map-visit": "^1.0.0",
@@ -7099,12 +7055,10 @@
     },
     "node_modules/commondir": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/compressible": {
@@ -7155,7 +7109,6 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -7244,8 +7197,7 @@
       "license": "MIT"
     },
     "node_modules/console-browserify": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -7254,7 +7206,6 @@
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -7321,7 +7272,6 @@
     },
     "node_modules/copy-concurrently": {
       "version": "1.0.5",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^1.1.1",
@@ -7334,7 +7284,6 @@
     },
     "node_modules/copy-concurrently/node_modules/rimraf": {
       "version": "2.7.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -7345,7 +7294,6 @@
     },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7542,7 +7490,6 @@
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.1.0",
@@ -7551,7 +7498,6 @@
     },
     "node_modules/create-ecdh/node_modules/bn.js": {
       "version": "4.12.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/create-hash": {
@@ -7632,7 +7578,6 @@
     },
     "node_modules/crypto-browserify": {
       "version": "3.12.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserify-cipher": "^1.0.0",
@@ -7928,7 +7873,6 @@
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d": {
@@ -8416,7 +8360,6 @@
     },
     "node_modules/define-property": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.2",
@@ -8428,7 +8371,6 @@
     },
     "node_modules/define-property/node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
@@ -8439,7 +8381,6 @@
     },
     "node_modules/define-property/node_modules/is-data-descriptor": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
@@ -8450,7 +8391,6 @@
     },
     "node_modules/define-property/node_modules/is-descriptor": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^1.0.0",
@@ -8601,7 +8541,6 @@
     },
     "node_modules/des.js": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -8660,7 +8599,6 @@
     },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.1.0",
@@ -8670,7 +8608,6 @@
     },
     "node_modules/diffie-hellman/node_modules/bn.js": {
       "version": "4.12.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dijkstrajs": {
@@ -8736,7 +8673,6 @@
     },
     "node_modules/domain-browser": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4",
@@ -9007,7 +8943,6 @@
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.0.0",
@@ -9018,12 +8953,10 @@
     },
     "node_modules/duplexify/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/duplexify/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -9037,12 +8970,10 @@
     },
     "node_modules/duplexify/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/duplexify/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -9125,7 +9056,6 @@
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -9262,7 +9192,6 @@
     },
     "node_modules/errno": {
       "version": "0.1.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prr": "~1.0.1"
@@ -9437,7 +9366,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "4.0.3",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.1.0",
@@ -9461,7 +9389,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -9472,7 +9399,6 @@
     },
     "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.2.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -9480,7 +9406,6 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -9631,7 +9556,6 @@
     },
     "node_modules/expand-brackets": {
       "version": "2.1.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^2.3.3",
@@ -9648,7 +9572,6 @@
     },
     "node_modules/expand-brackets/node_modules/debug": {
       "version": "2.6.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -9656,7 +9579,6 @@
     },
     "node_modules/expand-brackets/node_modules/define-property": {
       "version": "0.2.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -9667,7 +9589,6 @@
     },
     "node_modules/expand-brackets/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -9678,7 +9599,6 @@
     },
     "node_modules/expand-brackets/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/expect": {
@@ -9800,7 +9720,6 @@
     },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assign-symbols": "^1.0.0",
@@ -9812,7 +9731,6 @@
     },
     "node_modules/extend-shallow/node_modules/is-extendable": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4"
@@ -9836,7 +9754,6 @@
     },
     "node_modules/extglob": {
       "version": "2.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-unique": "^0.3.2",
@@ -9854,7 +9771,6 @@
     },
     "node_modules/extglob/node_modules/define-property": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -9865,7 +9781,6 @@
     },
     "node_modules/extglob/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -9876,7 +9791,6 @@
     },
     "node_modules/extglob/node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
@@ -9887,7 +9801,6 @@
     },
     "node_modules/extglob/node_modules/is-data-descriptor": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
@@ -9898,7 +9811,6 @@
     },
     "node_modules/extglob/node_modules/is-descriptor": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^1.0.0",
@@ -9968,7 +9880,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -10038,7 +9949,6 @@
     },
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/figures": {
@@ -10238,7 +10148,6 @@
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -10247,12 +10156,10 @@
     },
     "node_modules/flush-write-stream/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/flush-write-stream/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -10266,12 +10173,10 @@
     },
     "node_modules/flush-write-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/flush-write-stream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -10297,7 +10202,6 @@
     },
     "node_modules/for-in": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10358,7 +10262,6 @@
     },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "map-cache": "^0.2.2"
@@ -10377,7 +10280,6 @@
     },
     "node_modules/from2": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -10386,12 +10288,10 @@
     },
     "node_modules/from2/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/from2/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -10405,12 +10305,10 @@
     },
     "node_modules/from2/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/from2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -10446,7 +10344,6 @@
     },
     "node_modules/fs-write-stream-atomic": {
       "version": "1.0.10",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -10457,12 +10354,10 @@
     },
     "node_modules/fs-write-stream-atomic/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-write-stream-atomic/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -10476,12 +10371,10 @@
     },
     "node_modules/fs-write-stream-atomic/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-write-stream-atomic/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -10489,7 +10382,6 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -10677,7 +10569,6 @@
     },
     "node_modules/get-value": {
       "version": "2.0.6",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10779,7 +10670,6 @@
     },
     "node_modules/glob": {
       "version": "7.1.6",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -10798,7 +10688,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -11041,7 +10931,6 @@
     },
     "node_modules/has-value": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-value": "^2.0.6",
@@ -11054,7 +10943,6 @@
     },
     "node_modules/has-values": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^3.0.0",
@@ -11066,7 +10954,6 @@
     },
     "node_modules/has-values/node_modules/is-number": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11077,7 +10964,6 @@
     },
     "node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -11088,7 +10974,6 @@
     },
     "node_modules/has-values/node_modules/kind-of": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -11538,7 +11423,6 @@
     },
     "node_modules/https-browserify": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
@@ -11676,7 +11560,6 @@
     },
     "node_modules/iferr": {
       "version": "0.1.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ignore": {
@@ -11754,7 +11637,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -11770,12 +11652,10 @@
     },
     "node_modules/infer-owner": {
       "version": "1.0.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -11988,7 +11868,6 @@
     },
     "node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -11999,7 +11878,6 @@
     },
     "node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -12035,7 +11913,7 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -12059,7 +11937,6 @@
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-callable": {
@@ -12106,7 +11983,6 @@
     },
     "node_modules/is-data-descriptor": {
       "version": "0.1.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -12117,7 +11993,6 @@
     },
     "node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -12138,7 +12013,6 @@
     },
     "node_modules/is-descriptor": {
       "version": "0.1.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
@@ -12151,7 +12025,6 @@
     },
     "node_modules/is-descriptor/node_modules/kind-of": {
       "version": "5.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12173,7 +12046,6 @@
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12181,7 +12053,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12206,7 +12078,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -12322,7 +12194,6 @@
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -12431,7 +12302,6 @@
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12470,7 +12340,6 @@
     },
     "node_modules/isobject": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12774,7 +12643,6 @@
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -12788,7 +12656,6 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
@@ -13211,7 +13078,6 @@
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13452,7 +13318,6 @@
     },
     "node_modules/loader-runner": {
       "version": "2.4.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.3.0 <5.0.0 || >=5.10"
@@ -13763,7 +13628,6 @@
     },
     "node_modules/map-cache": {
       "version": "0.2.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13771,7 +13635,6 @@
     },
     "node_modules/map-visit": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-visit": "^1.0.0"
@@ -13815,7 +13678,6 @@
     },
     "node_modules/memory-fs": {
       "version": "0.4.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "errno": "^0.1.3",
@@ -13824,12 +13686,10 @@
     },
     "node_modules/memory-fs/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/memory-fs/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -13843,12 +13703,10 @@
     },
     "node_modules/memory-fs/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/memory-fs/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -13905,7 +13763,6 @@
     },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.0.0",
@@ -13917,7 +13774,6 @@
     },
     "node_modules/miller-rabin/node_modules/bn.js": {
       "version": "4.12.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mime": {
@@ -14019,7 +13875,6 @@
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -14126,7 +13981,6 @@
     },
     "node_modules/mississippi": {
       "version": "3.0.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "concat-stream": "^1.5.0",
@@ -14146,7 +14000,6 @@
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "for-in": "^1.0.2",
@@ -14158,7 +14011,6 @@
     },
     "node_modules/mixin-deep/node_modules/is-extendable": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4"
@@ -14255,7 +14107,6 @@
     },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^1.1.1",
@@ -14268,7 +14119,6 @@
     },
     "node_modules/move-concurrently/node_modules/rimraf": {
       "version": "2.7.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -14357,7 +14207,6 @@
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "arr-diff": "^4.0.0",
@@ -14450,7 +14299,6 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/netmask": {
@@ -14560,7 +14408,6 @@
     },
     "node_modules/node-libs-browser": {
       "version": "2.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert": "^1.1.1",
@@ -14590,7 +14437,6 @@
     },
     "node_modules/node-libs-browser/node_modules/assert": {
       "version": "1.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4.1.1",
@@ -14599,7 +14445,6 @@
     },
     "node_modules/node-libs-browser/node_modules/assert/node_modules/util": {
       "version": "0.10.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "2.0.1"
@@ -14607,7 +14452,6 @@
     },
     "node_modules/node-libs-browser/node_modules/buffer": {
       "version": "4.9.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.0.2",
@@ -14617,22 +14461,18 @@
     },
     "node_modules/node-libs-browser/node_modules/inherits": {
       "version": "2.0.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/node-libs-browser/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-libs-browser/node_modules/punycode": {
       "version": "1.4.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-libs-browser/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -14646,12 +14486,10 @@
     },
     "node_modules/node-libs-browser/node_modules/readable-stream/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/node-libs-browser/node_modules/readable-stream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -14659,12 +14497,10 @@
     },
     "node_modules/node-libs-browser/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-libs-browser/node_modules/util": {
       "version": "0.11.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "2.0.3"
@@ -14672,7 +14508,6 @@
     },
     "node_modules/node-libs-browser/node_modules/util/node_modules/inherits": {
       "version": "2.0.3",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/node-releases": {
@@ -14720,7 +14555,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14886,7 +14721,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14894,7 +14728,6 @@
     },
     "node_modules/object-copy": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "copy-descriptor": "^0.1.0",
@@ -14907,7 +14740,6 @@
     },
     "node_modules/object-copy/node_modules/define-property": {
       "version": "0.2.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -14918,7 +14750,6 @@
     },
     "node_modules/object-copy/node_modules/kind-of": {
       "version": "3.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -14957,7 +14788,6 @@
     },
     "node_modules/object-visit": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.0"
@@ -14984,7 +14814,6 @@
     },
     "node_modules/object.pick": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -15153,7 +14982,6 @@
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/os-name": {
@@ -15356,12 +15184,10 @@
     },
     "node_modules/pako": {
       "version": "1.0.11",
-      "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parallel-transform": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cyclist": "^1.0.1",
@@ -15371,12 +15197,10 @@
     },
     "node_modules/parallel-transform/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/parallel-transform/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -15390,12 +15214,10 @@
     },
     "node_modules/parallel-transform/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/parallel-transform/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -15430,7 +15252,6 @@
     },
     "node_modules/parse-asn1": {
       "version": "5.1.6",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "asn1.js": "^5.2.0",
@@ -15512,7 +15333,6 @@
     },
     "node_modules/pascalcase": {
       "version": "0.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15520,12 +15340,11 @@
     },
     "node_modules/path-browserify": {
       "version": "0.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-dirname": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/path-exists": {
@@ -15537,7 +15356,6 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15748,7 +15566,6 @@
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16615,7 +16432,6 @@
     },
     "node_modules/process": {
       "version": "0.11.10",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -16634,7 +16450,6 @@
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/promise-retry": {
@@ -17198,7 +17013,6 @@
     },
     "node_modules/prr": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pseudomap": {
@@ -17213,7 +17027,6 @@
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.1.0",
@@ -17226,7 +17039,6 @@
     },
     "node_modules/public-encrypt/node_modules/bn.js": {
       "version": "4.12.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -17239,7 +17051,6 @@
     },
     "node_modules/pumpify": {
       "version": "1.5.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "duplexify": "^3.6.0",
@@ -17249,7 +17060,6 @@
     },
     "node_modules/pumpify/node_modules/pump": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -17258,7 +17068,6 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17337,14 +17146,12 @@
     },
     "node_modules/querystring": {
       "version": "0.2.0",
-      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
     },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
-      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -17382,7 +17189,6 @@
     },
     "node_modules/randomfill": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "randombytes": "^2.0.5",
@@ -17570,7 +17376,7 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -17614,7 +17420,6 @@
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^3.0.2",
@@ -17692,12 +17497,11 @@
     },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/repeat-element": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17705,7 +17509,6 @@
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -18060,7 +17863,6 @@
     },
     "node_modules/resolve-url": {
       "version": "0.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve-url-loader": {
@@ -18203,7 +18005,6 @@
     },
     "node_modules/ret": {
       "version": "0.1.15",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12"
@@ -18344,7 +18145,6 @@
     },
     "node_modules/run-queue": {
       "version": "1.0.3",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^1.1.1"
@@ -18399,7 +18199,6 @@
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ret": "~0.1.10"
@@ -18407,7 +18206,6 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -18823,7 +18621,6 @@
     },
     "node_modules/set-value": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -18837,7 +18634,6 @@
     },
     "node_modules/set-value/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -19000,7 +18796,6 @@
     },
     "node_modules/snapdragon": {
       "version": "0.8.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base": "^0.11.1",
@@ -19018,7 +18813,6 @@
     },
     "node_modules/snapdragon-node": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-property": "^1.0.0",
@@ -19031,7 +18825,6 @@
     },
     "node_modules/snapdragon-node/node_modules/define-property": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -19042,7 +18835,6 @@
     },
     "node_modules/snapdragon-node/node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
@@ -19053,7 +18845,6 @@
     },
     "node_modules/snapdragon-node/node_modules/is-data-descriptor": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
@@ -19064,7 +18855,6 @@
     },
     "node_modules/snapdragon-node/node_modules/is-descriptor": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^1.0.0",
@@ -19077,7 +18867,6 @@
     },
     "node_modules/snapdragon-util": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.2.0"
@@ -19088,7 +18877,6 @@
     },
     "node_modules/snapdragon-util/node_modules/kind-of": {
       "version": "3.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -19099,7 +18887,6 @@
     },
     "node_modules/snapdragon/node_modules/debug": {
       "version": "2.6.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -19107,7 +18894,6 @@
     },
     "node_modules/snapdragon/node_modules/define-property": {
       "version": "0.2.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -19118,7 +18904,6 @@
     },
     "node_modules/snapdragon/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -19129,12 +18914,10 @@
     },
     "node_modules/snapdragon/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/snapdragon/node_modules/source-map": {
       "version": "0.5.7",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -19142,7 +18925,6 @@
     },
     "node_modules/snapdragon/node_modules/source-map-resolve": {
       "version": "0.5.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atob": "^2.1.2",
@@ -19303,7 +19085,6 @@
     },
     "node_modules/source-list-map": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/source-map": {
@@ -19383,7 +19164,6 @@
     },
     "node_modules/source-map-url": {
       "version": "0.4.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sourcemap-codec": {
@@ -19485,7 +19265,6 @@
     },
     "node_modules/split-string": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^3.0.0"
@@ -19571,7 +19350,6 @@
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-property": "^0.2.5",
@@ -19583,7 +19361,6 @@
     },
     "node_modules/static-extend/node_modules/define-property": {
       "version": "0.2.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -19602,7 +19379,6 @@
     },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.1",
@@ -19611,12 +19387,10 @@
     },
     "node_modules/stream-browserify/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-browserify/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -19630,12 +19404,10 @@
     },
     "node_modules/stream-browserify/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-browserify/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -19684,7 +19456,6 @@
     },
     "node_modules/stream-each": {
       "version": "1.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -19693,7 +19464,6 @@
     },
     "node_modules/stream-http": {
       "version": "2.8.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "builtin-status-codes": "^3.0.0",
@@ -19705,12 +19475,10 @@
     },
     "node_modules/stream-http/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-http/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -19724,12 +19492,10 @@
     },
     "node_modules/stream-http/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-http/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -19737,7 +19503,6 @@
     },
     "node_modules/stream-shift": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-splicer": {
@@ -20406,7 +20171,6 @@
     },
     "node_modules/through2": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
@@ -20415,12 +20179,10 @@
     },
     "node_modules/through2/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -20434,12 +20196,10 @@
     },
     "node_modules/through2/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -20468,7 +20228,6 @@
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "setimmediate": "^1.0.4"
@@ -20514,7 +20273,6 @@
     },
     "node_modules/to-arraybuffer": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-buffer": {
@@ -20532,7 +20290,6 @@
     },
     "node_modules/to-object-path": {
       "version": "0.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -20543,7 +20300,6 @@
     },
     "node_modules/to-object-path/node_modules/kind-of": {
       "version": "3.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -20561,7 +20317,6 @@
     },
     "node_modules/to-regex": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-property": "^2.0.2",
@@ -20850,7 +20605,6 @@
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tunnel": {
@@ -21067,7 +20821,6 @@
     },
     "node_modules/union-value": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "arr-union": "^3.1.0",
@@ -21086,7 +20839,6 @@
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "unique-slug": "^2.0.0"
@@ -21094,7 +20846,6 @@
     },
     "node_modules/unique-slug": {
       "version": "2.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
@@ -21127,7 +20878,6 @@
     },
     "node_modules/unset-value": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-value": "^0.3.1",
@@ -21139,7 +20889,6 @@
     },
     "node_modules/unset-value/node_modules/has-value": {
       "version": "0.3.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-value": "^2.0.3",
@@ -21152,7 +20901,6 @@
     },
     "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isarray": "1.0.0"
@@ -21163,7 +20911,6 @@
     },
     "node_modules/unset-value/node_modules/has-values": {
       "version": "0.1.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21171,7 +20918,6 @@
     },
     "node_modules/unset-value/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/untildify": {
@@ -21184,7 +20930,7 @@
     },
     "node_modules/upath": {
       "version": "1.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4",
@@ -21193,7 +20939,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -21201,12 +20946,10 @@
     },
     "node_modules/urix": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/url": {
       "version": "0.11.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "1.3.2",
@@ -21242,12 +20985,10 @@
     },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/use": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21348,7 +21089,6 @@
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/void-elements": {
@@ -21361,7 +21101,6 @@
     },
     "node_modules/watchpack": {
       "version": "1.7.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -21374,7 +21113,6 @@
     },
     "node_modules/watchpack-chokidar2": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21383,7 +21121,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/anymatch": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -21393,7 +21130,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/anymatch/node_modules/normalize-path": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21405,7 +21141,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/binary-extensions": {
       "version": "1.13.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -21414,7 +21149,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/braces": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21435,7 +21169,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21447,7 +21180,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/chokidar": {
       "version": "2.1.8",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21469,7 +21201,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/fill-range": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21484,7 +21215,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/fill-range/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21496,7 +21226,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/fsevents": {
       "version": "1.2.13",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -21513,7 +21242,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/glob-parent": {
       "version": "3.1.0",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -21523,7 +21251,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/glob-parent/node_modules/is-glob": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21535,7 +21262,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/is-binary-path": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21547,7 +21273,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/is-number": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21559,7 +21284,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21571,13 +21295,11 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/watchpack-chokidar2/node_modules/micromatch": {
       "version": "3.1.10",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21601,7 +21323,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21616,7 +21337,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/readdirp": {
       "version": "2.2.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21630,13 +21350,11 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/watchpack-chokidar2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21645,7 +21363,6 @@
     },
     "node_modules/watchpack-chokidar2/node_modules/to-regex-range": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -21686,7 +21403,6 @@
     },
     "node_modules/webpack": {
       "version": "4.44.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
@@ -22200,7 +21916,6 @@
     },
     "node_modules/webpack/node_modules/braces": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "arr-flatten": "^1.1.0",
@@ -22220,7 +21935,6 @@
     },
     "node_modules/webpack/node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -22231,7 +21945,6 @@
     },
     "node_modules/webpack/node_modules/cacache": {
       "version": "12.0.4",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "bluebird": "^3.5.5",
@@ -22253,12 +21966,10 @@
     },
     "node_modules/webpack/node_modules/chownr": {
       "version": "1.1.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/webpack/node_modules/enhanced-resolve": {
       "version": "4.5.0",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.5.0",
@@ -22270,7 +21981,6 @@
     },
     "node_modules/webpack/node_modules/enhanced-resolve/node_modules/memory-fs": {
       "version": "0.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "errno": "^0.1.3",
@@ -22282,7 +21992,6 @@
     },
     "node_modules/webpack/node_modules/fill-range": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -22296,7 +22005,6 @@
     },
     "node_modules/webpack/node_modules/fill-range/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -22307,7 +22015,6 @@
     },
     "node_modules/webpack/node_modules/find-cache-dir": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "commondir": "^1.0.1",
@@ -22320,7 +22027,6 @@
     },
     "node_modules/webpack/node_modules/is-number": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -22331,7 +22037,6 @@
     },
     "node_modules/webpack/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -22342,7 +22047,6 @@
     },
     "node_modules/webpack/node_modules/is-wsl": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -22350,12 +22054,10 @@
     },
     "node_modules/webpack/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/webpack/node_modules/json5": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
@@ -22366,7 +22068,6 @@
     },
     "node_modules/webpack/node_modules/loader-utils": {
       "version": "1.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
@@ -22379,7 +22080,6 @@
     },
     "node_modules/webpack/node_modules/lru-cache": {
       "version": "5.1.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -22387,7 +22087,6 @@
     },
     "node_modules/webpack/node_modules/make-dir": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^4.0.1",
@@ -22399,7 +22098,6 @@
     },
     "node_modules/webpack/node_modules/micromatch": {
       "version": "3.1.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "arr-diff": "^4.0.0",
@@ -22422,7 +22120,6 @@
     },
     "node_modules/webpack/node_modules/pify": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22430,7 +22127,6 @@
     },
     "node_modules/webpack/node_modules/pkg-dir": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^3.0.0"
@@ -22441,7 +22137,6 @@
     },
     "node_modules/webpack/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -22455,7 +22150,6 @@
     },
     "node_modules/webpack/node_modules/rimraf": {
       "version": "2.7.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -22466,12 +22160,10 @@
     },
     "node_modules/webpack/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.1.0",
@@ -22484,7 +22176,6 @@
     },
     "node_modules/webpack/node_modules/semver": {
       "version": "5.7.1",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -22492,7 +22183,6 @@
     },
     "node_modules/webpack/node_modules/serialize-javascript": {
       "version": "4.0.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -22500,7 +22190,6 @@
     },
     "node_modules/webpack/node_modules/ssri": {
       "version": "6.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "figgy-pudding": "^3.5.1"
@@ -22508,7 +22197,6 @@
     },
     "node_modules/webpack/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -22516,7 +22204,6 @@
     },
     "node_modules/webpack/node_modules/tapable": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22524,7 +22211,6 @@
     },
     "node_modules/webpack/node_modules/terser-webpack-plugin": {
       "version": "1.4.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cacache": "^12.0.2",
@@ -22546,7 +22232,6 @@
     },
     "node_modules/webpack/node_modules/to-regex-range": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^3.0.0",
@@ -22558,7 +22243,6 @@
     },
     "node_modules/webpack/node_modules/webpack-sources": {
       "version": "1.4.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "source-list-map": "^2.0.0",
@@ -22567,7 +22251,6 @@
     },
     "node_modules/webpack/node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/webrtc-adapter": {
@@ -22759,7 +22442,6 @@
     },
     "node_modules/worker-farm": {
       "version": "1.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "errno": "~0.1.7"
@@ -22909,7 +22591,6 @@
     },
     "node_modules/xtend": {
       "version": "4.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
@@ -23404,7 +23085,6 @@
     },
     "@angular/compiler": {
       "version": "11.2.14",
-      "dev": true,
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -24485,16 +24165,20 @@
     "@capacitor/android": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-3.3.3.tgz",
-      "integrity": "sha512-YfLW8gh/b3ZifmhQPFS9ybAnPp4MutQWGFYiAVecRh3O5nJD/UgZAmUmqpSoWRAOWbNGLX4lhWUIs+cCf552fg=="
+      "integrity": "sha512-YfLW8gh/b3ZifmhQPFS9ybAnPp4MutQWGFYiAVecRh3O5nJD/UgZAmUmqpSoWRAOWbNGLX4lhWUIs+cCf552fg==",
+      "requires": {}
     },
     "@capacitor/app": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "requires": {}
     },
     "@capacitor/app-launcher": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "requires": {}
     },
     "@capacitor/browser": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "requires": {}
     },
     "@capacitor/cli": {
       "version": "3.3.3",
@@ -24535,7 +24219,8 @@
       }
     },
     "@capacitor/clipboard": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "requires": {}
     },
     "@capacitor/core": {
       "version": "3.3.3",
@@ -24546,30 +24231,38 @@
       }
     },
     "@capacitor/filesystem": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "requires": {}
     },
     "@capacitor/haptics": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "requires": {}
     },
     "@capacitor/ios": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-3.3.3.tgz",
-      "integrity": "sha512-SQ35AaHUIJjjEX22wwdoN1sUZ3uMwG0HrZ0izMeBJBDE+vmNI78SP9wMqJxKuCaaX4oFKrxCtf/fQZGVTSxpCQ=="
+      "integrity": "sha512-SQ35AaHUIJjjEX22wwdoN1sUZ3uMwG0HrZ0izMeBJBDE+vmNI78SP9wMqJxKuCaaX4oFKrxCtf/fQZGVTSxpCQ==",
+      "requires": {}
     },
     "@capacitor/keyboard": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "requires": {}
     },
     "@capacitor/push-notifications": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "requires": {}
     },
     "@capacitor/share": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "requires": {}
     },
     "@capacitor/splash-screen": {
-      "version": "1.1.5"
+      "version": "1.1.5",
+      "requires": {}
     },
     "@capacitor/status-bar": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "requires": {}
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.2",
@@ -25378,7 +25071,8 @@
       }
     },
     "@polkadot/wasm-crypto": {
-      "version": "0.20.1"
+      "version": "0.20.1",
+      "requires": {}
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -25433,6 +25127,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
+    "@robingenz/capacitor-android-dark-mode-support": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@robingenz/capacitor-android-dark-mode-support/-/capacitor-android-dark-mode-support-1.0.1.tgz",
+      "integrity": "sha512-JayMLgSy/ZraS7ckSb1McBxFavUy25A334TZ6Xnd9FCEmhP6+0+WoZpSAlNPtl1EZbt/elKv13qxMhGCJmUZtw==",
+      "requires": {}
     },
     "@schematics/angular": {
       "version": "11.2.14",
@@ -25922,7 +25622,6 @@
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@webassemblyjs/helper-module-context": "1.9.0",
         "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
@@ -25930,42 +25629,34 @@
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.9.0",
-      "dev": true
+      "version": "1.9.0"
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.9.0",
-      "dev": true
+      "version": "1.9.0"
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.9.0",
-      "dev": true
+      "version": "1.9.0"
     },
     "@webassemblyjs/helper-code-frame": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@webassemblyjs/wast-printer": "1.9.0"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.9.0",
-      "dev": true
+      "version": "1.9.0"
     },
     "@webassemblyjs/helper-module-context": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.9.0",
-      "dev": true
+      "version": "1.9.0"
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-buffer": "1.9.0",
@@ -25975,25 +25666,21 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.9.0",
-      "dev": true
+      "version": "1.9.0"
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-buffer": "1.9.0",
@@ -26007,7 +25694,6 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
@@ -26018,7 +25704,6 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-buffer": "1.9.0",
@@ -26028,7 +25713,6 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-api-error": "1.9.0",
@@ -26040,7 +25724,6 @@
     },
     "@webassemblyjs/wast-parser": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/floating-point-hex-parser": "1.9.0",
@@ -26052,7 +25735,6 @@
     },
     "@webassemblyjs/wast-printer": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
@@ -26060,12 +25742,10 @@
       }
     },
     "@xtuc/ieee754": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "@xtuc/long": {
-      "version": "4.2.2",
-      "dev": true
+      "version": "4.2.2"
     },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -26184,8 +25864,7 @@
       }
     },
     "acorn": {
-      "version": "6.4.2",
-      "dev": true
+      "version": "6.4.2"
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -26247,7 +25926,6 @@
     },
     "ajv": {
       "version": "6.12.6",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -26257,11 +25935,11 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "dev": true
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -26357,7 +26035,7 @@
     },
     "anymatch": {
       "version": "3.1.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -26368,8 +26046,7 @@
       "dev": true
     },
     "aproba": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "arch": {
       "version": "2.2.0",
@@ -26458,16 +26135,13 @@
       }
     },
     "arr-diff": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "arr-flatten": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "arr-union": {
-      "version": "3.1.0",
-      "dev": true
+      "version": "3.1.0"
     },
     "array-differ": {
       "version": "2.1.0",
@@ -26486,8 +26160,7 @@
       "dev": true
     },
     "array-unique": {
-      "version": "0.3.2",
-      "dev": true
+      "version": "0.3.2"
     },
     "arrify": {
       "version": "1.0.1",
@@ -26502,7 +26175,6 @@
     },
     "asn1.js": {
       "version": "5.4.1",
-      "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -26511,8 +26183,7 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0",
-          "dev": true
+          "version": "4.12.0"
         }
       }
     },
@@ -26530,8 +26201,7 @@
       "dev": true
     },
     "assign-symbols": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "ast-types": {
       "version": "0.13.4",
@@ -26557,7 +26227,7 @@
     },
     "async-each": {
       "version": "1.0.3",
-      "dev": true
+      "devOptional": true
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -26571,8 +26241,7 @@
       "dev": true
     },
     "atob": {
-      "version": "2.1.2",
-      "dev": true
+      "version": "2.1.2"
     },
     "autoprefixer": {
       "version": "10.2.4",
@@ -26646,12 +26315,10 @@
       }
     },
     "balanced-match": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "base": {
       "version": "0.11.2",
-      "dev": true,
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -26664,28 +26331,24 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -26747,15 +26410,14 @@
       "dev": true
     },
     "big.js": {
-      "version": "5.2.2",
-      "dev": true
+      "version": "5.2.2"
     },
     "bignumber.js": {
       "version": "9.0.1"
     },
     "binary-extensions": {
       "version": "2.2.0",
-      "dev": true
+      "devOptional": true
     },
     "bindings": {
       "version": "1.5.0",
@@ -26854,8 +26516,7 @@
       }
     },
     "bluebird": {
-      "version": "3.7.2",
-      "dev": true
+      "version": "3.7.2"
     },
     "bn.js": {
       "version": "5.2.0"
@@ -26922,7 +26583,6 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -27143,7 +26803,6 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
-      "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -27152,7 +26811,6 @@
     },
     "browserify-des": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -27162,7 +26820,6 @@
     },
     "browserify-rsa": {
       "version": "4.1.0",
-      "dev": true,
       "requires": {
         "bn.js": "^5.0.0",
         "randombytes": "^2.0.1"
@@ -27170,7 +26827,6 @@
     },
     "browserify-sign": {
       "version": "4.2.1",
-      "dev": true,
       "requires": {
         "bn.js": "^5.1.1",
         "browserify-rsa": "^4.0.1",
@@ -27185,7 +26841,6 @@
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "dev": true,
       "requires": {
         "pako": "~1.0.5"
       }
@@ -27293,8 +26948,7 @@
       "dev": true
     },
     "builtin-status-codes": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "builtins": {
       "version": "1.0.3",
@@ -27335,7 +26989,6 @@
     },
     "cache-base": {
       "version": "1.0.1",
-      "dev": true,
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -27541,7 +27194,7 @@
     },
     "chokidar": {
       "version": "3.5.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -27558,8 +27211,7 @@
       "dev": true
     },
     "chrome-trace-event": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -27570,11 +27222,11 @@
     },
     "circular-dependency-plugin": {
       "version": "5.2.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "class-utils": {
       "version": "0.3.6",
-      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -27584,7 +27236,6 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -27741,11 +27392,13 @@
       "dependencies": {
         "@angular/compiler": {
           "version": "9.0.0",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "@angular/core": {
           "version": "9.0.0",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "source-map": {
           "version": "0.5.7",
@@ -27763,7 +27416,6 @@
     },
     "collection-visit": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -27827,12 +27479,10 @@
       "version": "4.1.1"
     },
     "commondir": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "component-emitter": {
-      "version": "1.3.0",
-      "dev": true
+      "version": "1.3.0"
     },
     "compressible": {
       "version": "2.0.18",
@@ -27872,8 +27522,7 @@
       }
     },
     "concat-map": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -27946,16 +27595,14 @@
       "dev": true
     },
     "console-browserify": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "console-control-strings": {
       "version": "1.1.0",
       "dev": true
     },
     "constants-browserify": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -28007,7 +27654,6 @@
     },
     "copy-concurrently": {
       "version": "1.0.5",
-      "dev": true,
       "requires": {
         "aproba": "^1.1.1",
         "fs-write-stream-atomic": "^1.0.8",
@@ -28019,7 +27665,6 @@
       "dependencies": {
         "rimraf": {
           "version": "2.7.1",
-          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -28027,8 +27672,7 @@
       }
     },
     "copy-descriptor": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "copy-webpack-plugin": {
       "version": "6.3.2",
@@ -28153,15 +27797,13 @@
     },
     "create-ecdh": {
       "version": "4.0.4",
-      "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.5.3"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0",
-          "dev": true
+          "version": "4.12.0"
         }
       }
     },
@@ -28230,7 +27872,6 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
         "browserify-sign": "^4.0.0",
@@ -28416,7 +28057,8 @@
     },
     "cssnano-utils": {
       "version": "2.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -28430,8 +28072,7 @@
       "dev": true
     },
     "cyclist": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "d": {
       "version": "1.0.1",
@@ -28767,7 +28408,6 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "dev": true,
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -28775,21 +28415,18 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -28892,7 +28529,6 @@
     },
     "des.js": {
       "version": "1.0.1",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -28931,7 +28567,6 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
@@ -28939,8 +28574,7 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0",
-          "dev": true
+          "version": "4.12.0"
         }
       }
     },
@@ -28993,8 +28627,7 @@
       }
     },
     "domain-browser": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "domelementtype": {
       "version": "2.2.0",
@@ -29190,7 +28823,6 @@
     },
     "duplexify": {
       "version": "3.7.1",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -29199,12 +28831,10 @@
       },
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -29216,12 +28846,10 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -29288,8 +28916,7 @@
       "version": "7.0.3"
     },
     "emojis-list": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -29338,7 +28965,8 @@
         },
         "ws": {
           "version": "7.4.6",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -29374,7 +29002,6 @@
     },
     "errno": {
       "version": "0.1.8",
-      "dev": true,
       "requires": {
         "prr": "~1.0.1"
       }
@@ -29493,7 +29120,6 @@
     },
     "eslint-scope": {
       "version": "4.0.3",
-      "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
@@ -29505,20 +29131,17 @@
     },
     "esrecurse": {
       "version": "4.3.0",
-      "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "dev": true
+          "version": "5.2.0"
         }
       }
     },
     "estraverse": {
-      "version": "4.3.0",
-      "dev": true
+      "version": "4.3.0"
     },
     "esutils": {
       "version": "2.0.3",
@@ -29628,7 +29251,6 @@
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "dev": true,
       "requires": {
         "debug": "^2.3.3",
         "define-property": "^0.2.5",
@@ -29641,28 +29263,24 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "define-property": {
           "version": "0.2.5",
-          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
         },
         "ms": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         }
       }
     },
@@ -29766,7 +29384,6 @@
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "dev": true,
       "requires": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -29774,7 +29391,6 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -29792,7 +29408,6 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "dev": true,
       "requires": {
         "array-unique": "^0.3.2",
         "define-property": "^1.0.0",
@@ -29806,35 +29421,30 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -29883,8 +29493,7 @@
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true
+      "version": "3.1.3"
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -29937,8 +29546,7 @@
       }
     },
     "figgy-pudding": {
-      "version": "3.5.2",
-      "dev": true
+      "version": "3.5.2"
     },
     "figures": {
       "version": "3.2.0",
@@ -30068,19 +29676,16 @@
     },
     "flush-write-stream": {
       "version": "1.1.1",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       },
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -30092,12 +29697,10 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -30108,8 +29711,7 @@
       "version": "1.14.1"
     },
     "for-in": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "foreach": {
       "version": "2.0.5"
@@ -30141,7 +29743,6 @@
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
       }
@@ -30152,19 +29753,16 @@
     },
     "from2": {
       "version": "2.3.0",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -30176,12 +29774,10 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -30209,7 +29805,6 @@
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "iferr": "^0.1.5",
@@ -30218,12 +29813,10 @@
       },
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -30235,12 +29828,10 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -30248,8 +29839,7 @@
       }
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "fsevents": {
       "version": "2.3.2",
@@ -30381,8 +29971,7 @@
       }
     },
     "get-value": {
-      "version": "2.0.6",
-      "dev": true
+      "version": "2.0.6"
     },
     "getpass": {
       "version": "0.1.7",
@@ -30454,7 +30043,6 @@
     },
     "glob": {
       "version": "7.1.6",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -30466,7 +30054,7 @@
     },
     "glob-parent": {
       "version": "5.1.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -30624,7 +30212,6 @@
     },
     "has-value": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -30633,7 +30220,6 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -30641,14 +30227,12 @@
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -30657,7 +30241,6 @@
         },
         "kind-of": {
           "version": "4.0.0",
-          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -31000,8 +30583,7 @@
       }
     },
     "https-browserify": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "https-proxy-agent": {
       "version": "5.0.0",
@@ -31071,14 +30653,14 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1"
     },
     "iferr": {
-      "version": "0.1.5",
-      "dev": true
+      "version": "0.1.5"
     },
     "ignore": {
       "version": "5.1.8",
@@ -31125,20 +30707,17 @@
       }
     },
     "imurmurhash": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "indent-string": {
       "version": "4.0.0",
       "dev": true
     },
     "infer-owner": {
-      "version": "1.0.4",
-      "dev": true
+      "version": "1.0.4"
     },
     "inflight": {
       "version": "1.0.6",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -31288,14 +30867,12 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -31317,7 +30894,7 @@
     },
     "is-binary-path": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -31329,8 +30906,7 @@
       }
     },
     "is-buffer": {
-      "version": "1.1.6",
-      "dev": true
+      "version": "1.1.6"
     },
     "is-callable": {
       "version": "1.2.3"
@@ -31362,14 +30938,12 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -31381,7 +30955,6 @@
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "dev": true,
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -31389,8 +30962,7 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "5.1.0",
-          "dev": true
+          "version": "5.1.0"
         }
       }
     },
@@ -31399,12 +30971,11 @@
       "dev": true
     },
     "is-extendable": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "is-extglob": {
       "version": "2.1.1",
-      "dev": true
+      "devOptional": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0"
@@ -31414,7 +30985,7 @@
     },
     "is-glob": {
       "version": "4.0.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -31475,7 +31046,6 @@
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -31530,8 +31100,7 @@
       "dev": true
     },
     "is-windows": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -31552,8 +31121,7 @@
       "dev": true
     },
     "isobject": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
     },
     "isstream": {
       "version": "0.1.2",
@@ -31754,8 +31322,7 @@
       "version": "3.0.0"
     },
     "json-parse-better-errors": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -31766,8 +31333,7 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true
+      "version": "0.4.1"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -32027,7 +31593,8 @@
     },
     "karma-jasmine-html-reporter": {
       "version": "1.7.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-source-map-support": {
       "version": "1.4.0",
@@ -32067,8 +31634,7 @@
       "dev": true
     },
     "kind-of": {
-      "version": "6.0.3",
-      "dev": true
+      "version": "6.0.3"
     },
     "kleur": {
       "version": "4.1.4",
@@ -32238,8 +31804,7 @@
       }
     },
     "loader-runner": {
-      "version": "2.4.0",
-      "dev": true
+      "version": "2.4.0"
     },
     "loader-utils": {
       "version": "2.0.0",
@@ -32463,12 +32028,10 @@
       }
     },
     "map-cache": {
-      "version": "0.2.2",
-      "dev": true
+      "version": "0.2.2"
     },
     "map-visit": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
       }
@@ -32498,19 +32061,16 @@
     },
     "memory-fs": {
       "version": "0.4.1",
-      "dev": true,
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
       },
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -32522,12 +32082,10 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -32569,15 +32127,13 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0",
-          "dev": true
+          "version": "4.12.0"
         }
       }
     },
@@ -32637,7 +32193,6 @@
     },
     "minimatch": {
       "version": "3.0.4",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -32708,7 +32263,6 @@
     },
     "mississippi": {
       "version": "3.0.0",
-      "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
         "duplexify": "^3.4.2",
@@ -32724,7 +32278,6 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "dev": true,
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -32732,7 +32285,6 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -32810,7 +32362,6 @@
     },
     "move-concurrently": {
       "version": "1.0.1",
-      "dev": true,
       "requires": {
         "aproba": "^1.1.1",
         "copy-concurrently": "^1.0.0",
@@ -32822,7 +32373,6 @@
       "dependencies": {
         "rimraf": {
           "version": "2.7.1",
-          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -32883,7 +32433,6 @@
     },
     "nanomatch": {
       "version": "1.2.13",
-      "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -32954,8 +32503,7 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.2",
-      "dev": true
+      "version": "2.6.2"
     },
     "netmask": {
       "version": "2.0.2",
@@ -33024,7 +32572,6 @@
     },
     "node-libs-browser": {
       "version": "2.2.1",
-      "dev": true,
       "requires": {
         "assert": "^1.1.1",
         "browserify-zlib": "^0.2.0",
@@ -33053,7 +32600,6 @@
       "dependencies": {
         "assert": {
           "version": "1.5.0",
-          "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "util": "0.10.3"
@@ -33061,7 +32607,6 @@
           "dependencies": {
             "util": {
               "version": "0.10.3",
-              "dev": true,
               "requires": {
                 "inherits": "2.0.1"
               }
@@ -33070,7 +32615,6 @@
         },
         "buffer": {
           "version": "4.9.2",
-          "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4",
@@ -33078,20 +32622,16 @@
           }
         },
         "inherits": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         },
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "punycode": {
-          "version": "1.4.1",
-          "dev": true
+          "version": "1.4.1"
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -33103,12 +32643,10 @@
           },
           "dependencies": {
             "inherits": {
-              "version": "2.0.4",
-              "dev": true
+              "version": "2.0.4"
             },
             "string_decoder": {
               "version": "1.1.1",
-              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -33116,19 +32654,16 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         },
         "util": {
           "version": "0.11.1",
-          "dev": true,
           "requires": {
             "inherits": "2.0.3"
           },
           "dependencies": {
             "inherits": {
-              "version": "2.0.3",
-              "dev": true
+              "version": "2.0.3"
             }
           }
         }
@@ -33167,7 +32702,7 @@
     },
     "normalize-path": {
       "version": "3.0.0",
-      "dev": true
+      "devOptional": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -33277,12 +32812,10 @@
       "dev": true
     },
     "object-assign": {
-      "version": "4.1.1",
-      "dev": true
+      "version": "4.1.1"
     },
     "object-copy": {
       "version": "0.1.0",
-      "dev": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -33291,14 +32824,12 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
           "version": "3.2.2",
-          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -33320,7 +32851,6 @@
     },
     "object-visit": {
       "version": "1.0.1",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.0"
       }
@@ -33336,7 +32866,6 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -33445,8 +32974,7 @@
       }
     },
     "os-browserify": {
-      "version": "0.3.0",
-      "dev": true
+      "version": "0.3.0"
     },
     "os-name": {
       "version": "4.0.1",
@@ -33570,12 +33098,10 @@
       }
     },
     "pako": {
-      "version": "1.0.11",
-      "dev": true
+      "version": "1.0.11"
     },
     "parallel-transform": {
       "version": "1.2.0",
-      "dev": true,
       "requires": {
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
@@ -33583,12 +33109,10 @@
       },
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -33600,12 +33124,10 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -33635,7 +33157,6 @@
     },
     "parse-asn1": {
       "version": "5.1.6",
-      "dev": true,
       "requires": {
         "asn1.js": "^5.2.0",
         "browserify-aes": "^1.0.0",
@@ -33695,23 +33216,20 @@
       }
     },
     "pascalcase": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "path-browserify": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "path-dirname": {
       "version": "1.0.2",
-      "dev": true
+      "devOptional": true
     },
     "path-exists": {
       "version": "3.0.0"
     },
     "path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -33844,8 +33362,7 @@
       }
     },
     "posix-character-classes": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "postcss": {
       "version": "8.2.15",
@@ -33883,19 +33400,23 @@
     },
     "postcss-discard-comments": {
       "version": "5.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-import": {
       "version": "14.0.0",
@@ -33985,7 +33506,8 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -34012,7 +33534,8 @@
     },
     "postcss-normalize-charset": {
       "version": "5.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -34334,8 +33857,7 @@
       "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
     },
     "process": {
-      "version": "0.11.10",
-      "dev": true
+      "version": "0.11.10"
     },
     "process-nextick-args": {
       "version": "2.0.1"
@@ -34344,8 +33866,7 @@
       "version": "2.0.3"
     },
     "promise-inflight": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "promise-retry": {
       "version": "1.1.1",
@@ -34736,8 +34257,7 @@
       "dev": true
     },
     "prr": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -34749,7 +34269,6 @@
     },
     "public-encrypt": {
       "version": "4.0.3",
-      "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
         "browserify-rsa": "^4.0.0",
@@ -34760,8 +34279,7 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0",
-          "dev": true
+          "version": "4.12.0"
         }
       }
     },
@@ -34774,7 +34292,6 @@
     },
     "pumpify": {
       "version": "1.5.1",
-      "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
@@ -34783,7 +34300,6 @@
       "dependencies": {
         "pump": {
           "version": "2.0.1",
-          "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -34792,8 +34308,7 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "dev": true
+      "version": "2.1.1"
     },
     "pushdata-bitcoin": {
       "version": "1.0.1",
@@ -34837,12 +34352,10 @@
       }
     },
     "querystring": {
-      "version": "0.2.0",
-      "dev": true
+      "version": "0.2.0"
     },
     "querystring-es3": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "querystringify": {
       "version": "2.2.0",
@@ -34860,7 +34373,6 @@
     },
     "randomfill": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
@@ -34998,7 +34510,7 @@
     },
     "readdirp": {
       "version": "3.6.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -35030,7 +34542,6 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -35082,15 +34593,13 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "dev": true
+      "devOptional": true
     },
     "repeat-element": {
-      "version": "1.1.4",
-      "dev": true
+      "version": "1.1.4"
     },
     "repeat-string": {
-      "version": "1.6.1",
-      "dev": true
+      "version": "1.6.1"
     },
     "replace": {
       "version": "1.2.1",
@@ -35330,8 +34839,7 @@
       "dev": true
     },
     "resolve-url": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "resolve-url-loader": {
       "version": "4.0.0",
@@ -35421,8 +34929,7 @@
       }
     },
     "ret": {
-      "version": "0.1.15",
-      "dev": true
+      "version": "0.1.15"
     },
     "retry": {
       "version": "0.12.0",
@@ -35502,7 +35009,6 @@
     },
     "run-queue": {
       "version": "1.0.3",
-      "dev": true,
       "requires": {
         "aproba": "^1.1.1"
       }
@@ -35530,14 +35036,12 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "dev": true,
       "requires": {
         "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
-      "version": "2.1.2",
-      "dev": true
+      "version": "2.1.2"
     },
     "sass": {
       "version": "1.32.6",
@@ -35830,7 +35334,6 @@
     },
     "set-value": {
       "version": "2.0.1",
-      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -35840,7 +35343,6 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -35938,7 +35440,6 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "dev": true,
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -35952,36 +35453,30 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "define-property": {
           "version": "0.2.5",
-          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
         },
         "ms": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "source-map": {
-          "version": "0.5.7",
-          "dev": true
+          "version": "0.5.7"
         },
         "source-map-resolve": {
           "version": "0.5.3",
-          "dev": true,
           "requires": {
             "atob": "^2.1.2",
             "decode-uri-component": "^0.2.0",
@@ -35994,7 +35489,6 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "dev": true,
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -36003,28 +35497,24 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -36035,14 +35525,12 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -36160,8 +35648,7 @@
       }
     },
     "source-list-map": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "source-map": {
       "version": "0.6.1"
@@ -36212,8 +35699,7 @@
       }
     },
     "source-map-url": {
-      "version": "0.4.1",
-      "dev": true
+      "version": "0.4.1"
     },
     "sourcemap-codec": {
       "version": "1.4.8",
@@ -36288,7 +35774,6 @@
     },
     "split-string": {
       "version": "3.1.0",
-      "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
       }
@@ -36347,7 +35832,6 @@
     },
     "static-extend": {
       "version": "0.1.2",
-      "dev": true,
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -36355,7 +35839,6 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -36368,19 +35851,16 @@
     },
     "stream-browserify": {
       "version": "2.0.2",
-      "dev": true,
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
       },
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -36392,12 +35872,10 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -36444,7 +35922,6 @@
     },
     "stream-each": {
       "version": "1.2.3",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "stream-shift": "^1.0.0"
@@ -36452,7 +35929,6 @@
     },
     "stream-http": {
       "version": "2.8.3",
-      "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.1",
@@ -36462,12 +35938,10 @@
       },
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -36479,12 +35953,10 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -36492,8 +35964,7 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "stream-splicer": {
       "version": "2.0.1",
@@ -36931,19 +36402,16 @@
     },
     "through2": {
       "version": "2.0.5",
-      "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       },
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -36955,12 +36423,10 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         },
         "string_decoder": {
           "version": "1.1.1",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -36981,7 +36447,6 @@
     },
     "timers-browserify": {
       "version": "2.0.12",
-      "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
       }
@@ -37013,8 +36478,7 @@
       }
     },
     "to-arraybuffer": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "to-buffer": {
       "version": "1.1.1",
@@ -37026,14 +36490,12 @@
     },
     "to-object-path": {
       "version": "0.3.0",
-      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -37045,7 +36507,6 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "dev": true,
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -37191,7 +36652,8 @@
     },
     "tslint-config-valorsoft": {
       "version": "2.2.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "tslint-plugin-prettier": {
       "version": "2.3.0",
@@ -37222,8 +36684,7 @@
       }
     },
     "tty-browserify": {
-      "version": "0.0.0",
-      "dev": true
+      "version": "0.0.0"
     },
     "tunnel": {
       "version": "0.0.6",
@@ -37353,7 +36814,6 @@
     },
     "union-value": {
       "version": "1.0.1",
-      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -37367,14 +36827,12 @@
     },
     "unique-filename": {
       "version": "1.1.1",
-      "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
       "version": "2.0.2",
-      "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
       }
@@ -37397,7 +36855,6 @@
     },
     "unset-value": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -37405,7 +36862,6 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "dev": true,
           "requires": {
             "get-value": "^2.0.3",
             "has-values": "^0.1.4",
@@ -37414,7 +36870,6 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "dev": true,
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -37422,12 +36877,10 @@
           }
         },
         "has-values": {
-          "version": "0.1.4",
-          "dev": true
+          "version": "0.1.4"
         },
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         }
       }
     },
@@ -37437,30 +36890,26 @@
     },
     "upath": {
       "version": "1.2.0",
-      "dev": true
+      "devOptional": true
     },
     "uri-js": {
       "version": "4.4.1",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
     },
     "urix": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "url": {
       "version": "0.11.0",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       },
       "dependencies": {
         "punycode": {
-          "version": "1.3.2",
-          "dev": true
+          "version": "1.3.2"
         }
       }
     },
@@ -37483,8 +36932,7 @@
       "dev": true
     },
     "use": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "utf-8-validate": {
       "version": "5.0.5",
@@ -37552,8 +37000,7 @@
       }
     },
     "vm-browserify": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.1.2"
     },
     "void-elements": {
       "version": "2.0.1",
@@ -37561,7 +37008,6 @@
     },
     "watchpack": {
       "version": "1.7.5",
-      "dev": true,
       "requires": {
         "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
@@ -37571,7 +37017,6 @@
     },
     "watchpack-chokidar2": {
       "version": "2.0.1",
-      "dev": true,
       "optional": true,
       "requires": {
         "chokidar": "^2.1.8"
@@ -37579,7 +37024,6 @@
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
-          "dev": true,
           "optional": true,
           "requires": {
             "micromatch": "^3.1.4",
@@ -37588,7 +37032,6 @@
           "dependencies": {
             "normalize-path": {
               "version": "2.1.1",
-              "dev": true,
               "optional": true,
               "requires": {
                 "remove-trailing-separator": "^1.0.1"
@@ -37598,12 +37041,10 @@
         },
         "binary-extensions": {
           "version": "1.13.1",
-          "dev": true,
           "optional": true
         },
         "braces": {
           "version": "2.3.2",
-          "dev": true,
           "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -37620,7 +37061,6 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "dev": true,
               "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -37630,7 +37070,6 @@
         },
         "chokidar": {
           "version": "2.1.8",
-          "dev": true,
           "optional": true,
           "requires": {
             "anymatch": "^2.0.0",
@@ -37649,7 +37088,6 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "dev": true,
           "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -37660,7 +37098,6 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "dev": true,
               "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -37670,7 +37107,6 @@
         },
         "fsevents": {
           "version": "1.2.13",
-          "dev": true,
           "optional": true,
           "requires": {
             "bindings": "^1.5.0",
@@ -37679,7 +37115,6 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "dev": true,
           "optional": true,
           "requires": {
             "is-glob": "^3.1.0",
@@ -37688,7 +37123,6 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "dev": true,
               "optional": true,
               "requires": {
                 "is-extglob": "^2.1.0"
@@ -37698,7 +37132,6 @@
         },
         "is-binary-path": {
           "version": "1.0.1",
-          "dev": true,
           "optional": true,
           "requires": {
             "binary-extensions": "^1.0.0"
@@ -37706,7 +37139,6 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "dev": true,
           "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -37714,7 +37146,6 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "dev": true,
               "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -37724,12 +37155,10 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "dev": true,
           "optional": true
         },
         "micromatch": {
           "version": "3.1.10",
-          "dev": true,
           "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -37749,7 +37178,6 @@
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -37763,7 +37191,6 @@
         },
         "readdirp": {
           "version": "2.2.1",
-          "dev": true,
           "optional": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -37773,12 +37200,10 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "dev": true,
           "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -37786,7 +37211,6 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "dev": true,
           "optional": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -37819,7 +37243,6 @@
     },
     "webpack": {
       "version": "4.44.2",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-module-context": "1.9.0",
@@ -37848,7 +37271,6 @@
       "dependencies": {
         "braces": {
           "version": "2.3.2",
-          "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -37864,7 +37286,6 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -37873,7 +37294,6 @@
         },
         "cacache": {
           "version": "12.0.4",
-          "dev": true,
           "requires": {
             "bluebird": "^3.5.5",
             "chownr": "^1.1.1",
@@ -37893,12 +37313,10 @@
           }
         },
         "chownr": {
-          "version": "1.1.4",
-          "dev": true
+          "version": "1.1.4"
         },
         "enhanced-resolve": {
           "version": "4.5.0",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "memory-fs": "^0.5.0",
@@ -37907,7 +37325,6 @@
           "dependencies": {
             "memory-fs": {
               "version": "0.5.0",
-              "dev": true,
               "requires": {
                 "errno": "^0.1.3",
                 "readable-stream": "^2.0.1"
@@ -37917,7 +37334,6 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -37927,7 +37343,6 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -37936,7 +37351,6 @@
         },
         "find-cache-dir": {
           "version": "2.1.0",
-          "dev": true,
           "requires": {
             "commondir": "^1.0.1",
             "make-dir": "^2.0.0",
@@ -37945,14 +37359,12 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -37960,23 +37372,19 @@
           }
         },
         "is-wsl": {
-          "version": "1.1.0",
-          "dev": true
+          "version": "1.1.0"
         },
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "json5": {
           "version": "1.0.1",
-          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
         },
         "loader-utils": {
           "version": "1.4.0",
-          "dev": true,
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -37985,14 +37393,12 @@
         },
         "lru-cache": {
           "version": "5.1.1",
-          "dev": true,
           "requires": {
             "yallist": "^3.0.2"
           }
         },
         "make-dir": {
           "version": "2.1.0",
-          "dev": true,
           "requires": {
             "pify": "^4.0.1",
             "semver": "^5.6.0"
@@ -38000,7 +37406,6 @@
         },
         "micromatch": {
           "version": "3.1.10",
-          "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -38018,19 +37423,16 @@
           }
         },
         "pify": {
-          "version": "4.0.1",
-          "dev": true
+          "version": "4.0.1"
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "dev": true,
           "requires": {
             "find-up": "^3.0.0"
           }
         },
         "readable-stream": {
           "version": "2.3.7",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -38043,18 +37445,15 @@
         },
         "rimraf": {
           "version": "2.7.1",
-          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         },
         "schema-utils": {
           "version": "1.0.0",
-          "dev": true,
           "requires": {
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
@@ -38062,37 +37461,31 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "dev": true
+          "version": "5.7.1"
         },
         "serialize-javascript": {
           "version": "4.0.0",
-          "dev": true,
           "requires": {
             "randombytes": "^2.1.0"
           }
         },
         "ssri": {
           "version": "6.0.2",
-          "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
           }
         },
         "string_decoder": {
           "version": "1.1.1",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
         },
         "tapable": {
-          "version": "1.1.3",
-          "dev": true
+          "version": "1.1.3"
         },
         "terser-webpack-plugin": {
           "version": "1.4.5",
-          "dev": true,
           "requires": {
             "cacache": "^12.0.2",
             "find-cache-dir": "^2.1.0",
@@ -38107,7 +37500,6 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "dev": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
@@ -38115,15 +37507,13 @@
         },
         "webpack-sources": {
           "version": "1.4.3",
-          "dev": true,
           "requires": {
             "source-list-map": "^2.0.0",
             "source-map": "~0.6.1"
           }
         },
         "yallist": {
-          "version": "3.1.1",
-          "dev": true
+          "version": "3.1.1"
         }
       }
     },
@@ -38590,7 +37980,6 @@
     },
     "worker-farm": {
       "version": "1.7.0",
-      "dev": true,
       "requires": {
         "errno": "~0.1.7"
       }
@@ -38659,7 +38048,8 @@
       }
     },
     "ws": {
-      "version": "7.3.0"
+      "version": "7.3.0",
+      "requires": {}
     },
     "xhr2-cookies": {
       "version": "1.1.0",
@@ -38690,8 +38080,7 @@
       "dev": true
     },
     "xtend": {
-      "version": "4.0.2",
-      "dev": true
+      "version": "4.0.2"
     },
     "y18n": {
       "version": "4.0.3"

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@ngx-translate/core": "^13.0.0",
     "@ngx-translate/http-loader": "^6.0.0",
     "@obsidiansystems/hw-app-xtz": "^4.72.3",
+    "@robingenz/capacitor-android-dark-mode-support": "^1.0.1",
     "@sentry/browser": "6.2.5",
     "@taquito/taquito": "^10.0.0",
     "@types/ledgerhq__hw-transport": "^4.21.2",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -99,19 +99,25 @@ export class AppComponent implements AfterViewInit {
   }
 
   public async initializeApp(): Promise<void> {
-    this.themeService.register()
-
     await Promise.all([this.initializeTranslations(), this.platform.ready(), this.initializeProtocols(), this.initializeWalletConnect()])
+
+    this.themeService.register()
 
     if (this.platform.is('hybrid')) {
       await Promise.all([
         this.statusBar.setStyle({ style: this.themeService.isDarkMode() ? Style.Dark : Style.Light }),
-        this.statusBar.setBackgroundColor({ color: this.themeService.isDarkMode() ? '#000000' : '#FFFFFF' }),
+        // Do we have different colors for android and iOS? if so, #121212 (Material Design) should be changed to respect such.
+        this.statusBar.setBackgroundColor({ color: this.themeService.isDarkMode() ? '#1f1f1f' : '#FFFFFF' }),
 
         this.splashScreen.hide(),
-
         this.pushProvider.initPush()
       ])
+
+      // Should this be placed elseWhere? It is necessary for the statusBar to dynamically change when themeSubject is changed.
+      this.themeService.themeSubject.subscribe((theme) => {
+        this.statusBar.setStyle({ style: this.themeService.isDarkMode(theme) ? Style.Dark : Style.Light })
+        this.statusBar.setBackgroundColor({ color: this.themeService.isDarkMode(theme) ? '#1f1f1f' : '#FFFFFF' })
+      })
 
       this.appInfo
         .get()

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -106,18 +106,11 @@ export class AppComponent implements AfterViewInit {
     if (this.platform.is('hybrid')) {
       await Promise.all([
         this.statusBar.setStyle({ style: this.themeService.isDarkMode() ? Style.Dark : Style.Light }),
-        // Do we have different colors for android and iOS? if so, #121212 (Material Design) should be changed to respect such.
-        this.statusBar.setBackgroundColor({ color: this.themeService.isDarkMode() ? '#1f1f1f' : '#FFFFFF' }),
+        this.statusBar.setBackgroundColor({ color: this.themeService.isDarkMode() ? '#121212' : '#FFFFFF' }),
 
         this.splashScreen.hide(),
         this.pushProvider.initPush()
       ])
-
-      // Should this be placed elseWhere? It is necessary for the statusBar to dynamically change when themeSubject is changed.
-      this.themeService.themeSubject.subscribe((theme) => {
-        this.statusBar.setStyle({ style: this.themeService.isDarkMode(theme) ? Style.Dark : Style.Light })
-        this.statusBar.setBackgroundColor({ color: this.themeService.isDarkMode(theme) ? '#1f1f1f' : '#FFFFFF' })
-      })
 
       this.appInfo
         .get()

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -51,6 +51,7 @@ import { TranslateService } from '@ngx-translate/core'
 import { Subscription } from 'rxjs'
 
 import { AccountProvider } from './services/account/account.provider'
+import { ThemeService } from './services/appearance/theme.service'
 import { DataService, DataServiceKey } from './services/data/data.service'
 import { IACService } from './services/iac/iac.service'
 import { PushProvider } from './services/push/push'
@@ -86,6 +87,7 @@ export class AppComponent implements AfterViewInit {
     private readonly config: Config,
     private readonly ngZone: NgZone,
     private readonly saplingNativeService: SaplingNativeService,
+    private readonly themeService: ThemeService,
     @Inject(APP_PLUGIN) private readonly app: AppPlugin,
     @Inject(APP_INFO_PLUGIN) private readonly appInfo: AppInfoPlugin,
     @Inject(SPLASH_SCREEN_PLUGIN) private readonly splashScreen: SplashScreenPlugin,
@@ -97,12 +99,16 @@ export class AppComponent implements AfterViewInit {
   }
 
   public async initializeApp(): Promise<void> {
+
+    this.themeService.register()
+
     await Promise.all([this.initializeTranslations(), this.platform.ready(), this.initializeProtocols(), this.initializeWalletConnect()])
 
     if (this.platform.is('hybrid')) {
       await Promise.all([
-        this.statusBar.setStyle({ style: Style.Light }),
-        this.statusBar.setBackgroundColor({ color: '#FFFFFF' }),
+        this.statusBar.setStyle({ style: true ? Style.Dark : Style.Light  }),
+        this.statusBar.setBackgroundColor({ color: true ? "#000000" : '#FFFFFF' }),
+
         this.splashScreen.hide(),
 
         this.pushProvider.initPush()

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,8 +8,7 @@ import {
   LanguageService,
   ProtocolService,
   SerializerService,
-  SPLASH_SCREEN_PLUGIN,
-  STATUS_BAR_PLUGIN
+  SPLASH_SCREEN_PLUGIN
 } from '@airgap/angular-core'
 import {
   AirGapMarketWallet,
@@ -45,7 +44,6 @@ import { AfterViewInit, Component, Inject, NgZone } from '@angular/core'
 import { Router } from '@angular/router'
 import { AppPlugin, URLOpenListenerEvent } from '@capacitor/app'
 import { SplashScreenPlugin } from '@capacitor/splash-screen'
-import { StatusBarPlugin, Style } from '@capacitor/status-bar'
 import { Config, Platform } from '@ionic/angular'
 import { TranslateService } from '@ngx-translate/core'
 import { Subscription } from 'rxjs'
@@ -90,8 +88,7 @@ export class AppComponent implements AfterViewInit {
     private readonly themeService: ThemeService,
     @Inject(APP_PLUGIN) private readonly app: AppPlugin,
     @Inject(APP_INFO_PLUGIN) private readonly appInfo: AppInfoPlugin,
-    @Inject(SPLASH_SCREEN_PLUGIN) private readonly splashScreen: SplashScreenPlugin,
-    @Inject(STATUS_BAR_PLUGIN) private readonly statusBar: StatusBarPlugin
+    @Inject(SPLASH_SCREEN_PLUGIN) private readonly splashScreen: SplashScreenPlugin
   ) {
     this.initializeApp().catch(handleErrorSentry(ErrorCategory.OTHER))
     this.isMobile = this.platform.is('android') || this.platform.is('ios')
@@ -103,14 +100,10 @@ export class AppComponent implements AfterViewInit {
 
     this.themeService.register()
 
-    if (this.platform.is('hybrid')) {
-      await Promise.all([
-        this.statusBar.setStyle({ style: this.themeService.isDarkMode() ? Style.Dark : Style.Light }),
-        this.statusBar.setBackgroundColor({ color: this.themeService.isDarkMode() ? '#121212' : '#FFFFFF' }),
+    this.themeService.statusBarStyleDark(await this.themeService.isDarkMode())
 
-        this.splashScreen.hide(),
-        this.pushProvider.initPush()
-      ])
+    if (this.platform.is('hybrid')) {
+      await Promise.all([this.splashScreen.hide(), this.pushProvider.initPush()])
 
       this.appInfo
         .get()

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -99,15 +99,14 @@ export class AppComponent implements AfterViewInit {
   }
 
   public async initializeApp(): Promise<void> {
-
     this.themeService.register()
 
     await Promise.all([this.initializeTranslations(), this.platform.ready(), this.initializeProtocols(), this.initializeWalletConnect()])
 
     if (this.platform.is('hybrid')) {
       await Promise.all([
-        this.statusBar.setStyle({ style: true ? Style.Dark : Style.Light  }),
-        this.statusBar.setBackgroundColor({ color: true ? "#000000" : '#FFFFFF' }),
+        this.statusBar.setStyle({ style: this.themeService.isDarkMode() ? Style.Dark : Style.Light }),
+        this.statusBar.setBackgroundColor({ color: this.themeService.isDarkMode() ? '#000000' : '#FFFFFF' }),
 
         this.splashScreen.hide(),
 
@@ -262,7 +261,7 @@ export class AppComponent implements AfterViewInit {
     const identifiersWithOptions = Object.entries(genericSubProtocols)
     const protocols = identifiersWithOptions
       .map(([protocolNetworkIdentifier, options]) => {
-        const [protocolIdentifier,] = protocolNetworkIdentifier.split(':')
+        const [protocolIdentifier] = protocolNetworkIdentifier.split(':')
 
         if (protocolIdentifier.startsWith(MainProtocolSymbols.XTZ)) {
           const tezosOptions = options as TezosProtocolOptions
@@ -333,7 +332,7 @@ export class AppComponent implements AfterViewInit {
       [TezosNetwork.EDONET]: 'KT1JJbWfW8CHUY95hG9iq2CEMma1RiKhMHDR',
       [TezosNetwork.FLORENCENET]: 'KT1PfBfkfUuvQRN8zuCAyp5MHjNrQqgevS9p',
       [TezosNetwork.GRANADANET]: 'KT1Ch6PstAQG32uNfQJUSL2bf2WvimvY5umk',
-      [TezosNetwork.HANGZHOUNET]: 'KT1MgQjmWMBQ4LyuMAqZccTkMSUJbEXeGqii',
+      [TezosNetwork.HANGZHOUNET]: 'KT1MgQjmWMBQ4LyuMAqZccTkMSUJbEXeGqii'
     }
 
     const tezosNetworks: TezosProtocolNetwork[] = (await this.protocolService.getNetworksForProtocol(

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -62,6 +62,7 @@ import { ProtocolSelectPageModule } from './pages/protocol-select/protocol-selec
 import { PipesModule } from './pipes/pipes.module'
 import { ShortenStringPipe } from './pipes/shorten-string/shorten-string.pipe'
 import { AccountProvider } from './services/account/account.provider'
+import { ThemeService } from './services/appearance/theme.service'
 import { CoinlibService } from './services/coinlib/coinlib.service'
 import { DrawChartService } from './services/draw-chart/draw-chart.service'
 import { ExchangeProvider } from './services/exchange/exchange'
@@ -172,8 +173,9 @@ export function createTranslateLoader(http: HttpClient): AirGapTranslateLoader {
     TransactionHashGuard,
     PercentPipe,
     FeeConverterPipe,
-    InteractionService
-  ],
+    InteractionService,
+    ThemeService
+   ],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/src/app/pages/settings/settings.html
+++ b/src/app/pages/settings/settings.html
@@ -13,6 +13,20 @@
   <ion-grid fixed="true" class="ion-no-padding">
     <ion-list lines="none">
       <ion-list-header class="ion-no-margin" lines="none">
+        <ion-label>{{ 'settings.appearance_label' | translate }}</ion-label>
+      </ion-list-header>
+      <ion-item>
+        <ion-icon name="build-outline" slot="start"></ion-icon>
+        {{ 'settings.theme_label' | translate }}
+        <ion-select [attr.value]="this.themeService.getTheme()" (ionChange)="onThemeSelection($event)" interface="action-sheet" slot="end">
+          <ion-select-option *ngIf="this.themeService.supportsSystemPref" value="system">Device Theme</ion-select-option>
+          <ion-select-option value="light">Light Theme</ion-select-option>
+          <ion-select-option value="dark">Dark Theme</ion-select-option>
+        </ion-select>
+      </ion-item>
+    </ion-list>
+    <ion-list lines="none">
+      <ion-list-header class="ion-no-margin" lines="none">
         <ion-label>{{ 'settings.help_label' | translate }}</ion-label>
       </ion-list-header>
       <ion-item (click)="introduction()" detail="true">

--- a/src/app/pages/settings/settings.html
+++ b/src/app/pages/settings/settings.html
@@ -18,8 +18,10 @@
       <ion-item>
         <ion-icon name="build-outline" slot="start"></ion-icon>
         {{ 'settings.theme_label' | translate }}
-        <ion-select [attr.value]="this.themeService.getTheme()" (ionChange)="onThemeSelection($event)" interface="action-sheet" slot="end">
-          <ion-select-option *ngIf="this.themeService.supportsSystemPref" value="system">{{ 'settings.select-theme.system' | translate }}</ion-select-option>
+        <ion-select [attr.value]="this.getTheme | async" (ionChange)="onThemeSelection($event)" interface="action-sheet" slot="end">
+          <ion-select-option *ngIf="this.themeService.supportsSystemPref" value="system">
+            {{ 'settings.select-theme.system' | translate }}
+          </ion-select-option>
           <ion-select-option value="light">{{ 'settings.select-theme.light' | translate }}</ion-select-option>
           <ion-select-option value="dark">{{ 'settings.select-theme.dark' | translate }}</ion-select-option>
         </ion-select>

--- a/src/app/pages/settings/settings.html
+++ b/src/app/pages/settings/settings.html
@@ -19,9 +19,9 @@
         <ion-icon name="build-outline" slot="start"></ion-icon>
         {{ 'settings.theme_label' | translate }}
         <ion-select [attr.value]="this.themeService.getTheme()" (ionChange)="onThemeSelection($event)" interface="action-sheet" slot="end">
-          <ion-select-option *ngIf="this.themeService.supportsSystemPref" value="system">Device Theme</ion-select-option>
-          <ion-select-option value="light">Light Theme</ion-select-option>
-          <ion-select-option value="dark">Dark Theme</ion-select-option>
+          <ion-select-option *ngIf="this.themeService.supportsSystemPref" value="system">{{ 'settings.select-theme.system' | translate }}</ion-select-option>
+          <ion-select-option value="light">{{ 'settings.select-theme.light' | translate }}</ion-select-option>
+          <ion-select-option value="dark">{{ 'settings.select-theme.dark' | translate }}</ion-select-option>
         </ion-select>
       </ion-item>
     </ion-list>

--- a/src/app/pages/settings/settings.ts
+++ b/src/app/pages/settings/settings.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router'
 import { Capacitor } from '@capacitor/core'
 import { SharePlugin } from '@capacitor/share'
 import { AlertController, ModalController } from '@ionic/angular'
+import { ThemeService } from 'src/app/services/appearance/theme.service'
 import { SHARE_PLUGIN } from 'src/app/capacitor-plugins/injection-tokens'
 import { BrowserService } from 'src/app/services/browser/browser.service'
 import { IACService } from 'src/app/services/iac/iac.service'
@@ -21,6 +22,7 @@ export class SettingsPage {
   constructor(
     public readonly alertCtrl: AlertController,
     public readonly serializerService: SerializerService,
+    public readonly themeService: ThemeService,
     private readonly router: Router,
     private readonly modalController: ModalController,
     private readonly clipboardProvider: ClipboardService,
@@ -28,6 +30,13 @@ export class SettingsPage {
     private readonly browserService: BrowserService,
     @Inject(SHARE_PLUGIN) private readonly sharePlugin: SharePlugin
   ) {}
+
+  public onThemeSelection(event): void {
+    const pref = event.detail.value
+
+    this.themeService.themeSubject.next(pref)
+    this.themeService.setStorageItem(pref)
+  }
 
   public about(): void {
     this.navigate('/about')

--- a/src/app/pages/settings/settings.ts
+++ b/src/app/pages/settings/settings.ts
@@ -32,10 +32,8 @@ export class SettingsPage {
   ) {}
 
   public onThemeSelection(event): void {
-    const pref = event.detail.value
-
-    this.themeService.themeSubject.next(pref)
-    this.themeService.setStorageItem(pref)
+    this.themeService.themeSubject.next(event.detail.value)
+    this.themeService.setStorageItem(event.detail.value)
   }
 
   public about(): void {

--- a/src/app/pages/settings/settings.ts
+++ b/src/app/pages/settings/settings.ts
@@ -18,6 +18,7 @@ import { IntroductionPage } from '../introduction/introduction'
 })
 export class SettingsPage {
   public readonly platform: string = Capacitor.getPlatform()
+  public readonly getTheme = this.themeService.getTheme()
 
   constructor(
     public readonly alertCtrl: AlertController,
@@ -31,9 +32,10 @@ export class SettingsPage {
     @Inject(SHARE_PLUGIN) private readonly sharePlugin: SharePlugin
   ) {}
 
-  public onThemeSelection(event): void {
+  public async onThemeSelection(event) {
     this.themeService.themeSubject.next(event.detail.value)
-    this.themeService.setStorageItem(event.detail.value)
+
+    await this.themeService.setStorageItem(event.detail.value)
   }
 
   public about(): void {

--- a/src/app/services/appearance/theme.service.ts
+++ b/src/app/services/appearance/theme.service.ts
@@ -13,34 +13,27 @@ export class ThemeService {
 
   public readonly supportsSystemPref = CSS.supports('color-scheme', 'dark')
 
-  constructor() {}
-
   public register() {
     this.systemThemeQuery().addEventListener('change', () => {
       this.themeSubject.next(this.getTheme())
     })
 
-    this.themeSubject.subscribe((value: themeOptions) => {
-      switch (value) {
-        case 'light':
-          this.toggleDarkMode(false)
-          return
-        case 'dark':
-          this.toggleDarkMode(true)
-          return
-        default:
-          this.toggleDarkMode(this.systemThemeQuery().matches ? true : false)
-          return
+    this.themeSubject.subscribe((theme) => {
+      if (this.isDarkMode(theme)) {
+        this.toggleDarkMode(true)
+        return
       }
+
+      this.toggleDarkMode(false)
     })
 
     this.themeSubject.next(this.getTheme())
   }
 
-  public isDarkMode(): boolean {
-    const theme = this.getTheme()
+  public isDarkMode(theme?: themeOptions): boolean {
+    theme = theme ?? this.getTheme()
 
-    if (theme == 'dark' || (theme == 'system' && this.systemThemeQuery().matches)) {
+    if (theme === 'dark' || this.systemPrefersDark(theme)) {
       return true
     }
 
@@ -51,8 +44,8 @@ export class ThemeService {
     document.body.classList.toggle('dark', enabled)
   }
 
-  public setStorageItem(pref: themeOptions): void {
-    localStorage.setItem(this.storageKey, pref)
+  public setStorageItem(theme: themeOptions): void {
+    localStorage.setItem(this.storageKey, theme)
   }
 
   public getTheme(): themeOptions {
@@ -71,5 +64,9 @@ export class ThemeService {
 
   private fallBackTheme(): themeOptions {
     return this.supportsSystemPref ? 'system' : 'light'
+  }
+
+  private systemPrefersDark(theme: themeOptions): boolean {
+    return theme === 'system' && this.systemThemeQuery().matches
   }
 }

--- a/src/app/services/appearance/theme.service.ts
+++ b/src/app/services/appearance/theme.service.ts
@@ -38,6 +38,16 @@ export class ThemeService {
     this.themeSubject.next(this.getTheme())
   }
 
+  public isDarkMode(): boolean {
+    const theme = this.getTheme()
+
+    if (theme == 'dark' || (theme == 'system' && this.systemThemeQuery().matches)) {
+      return true
+    }
+
+    return false
+  }
+
   public toggleDarkMode(enabled: boolean): void {
     document.body.classList.toggle('dark', enabled)
   }

--- a/src/app/services/appearance/theme.service.ts
+++ b/src/app/services/appearance/theme.service.ts
@@ -1,4 +1,6 @@
-import { Injectable } from '@angular/core'
+import { STATUS_BAR_PLUGIN } from '@airgap/angular-core'
+import { Inject, Injectable } from '@angular/core'
+import { StatusBarPlugin, Style } from '@capacitor/status-bar'
 import { Subject } from 'rxjs'
 
 type themeOptions = 'light' | 'dark' | 'system'
@@ -13,6 +15,8 @@ export class ThemeService {
 
   public readonly supportsSystemPref = CSS.supports('color-scheme', 'dark')
 
+  constructor(@Inject(STATUS_BAR_PLUGIN) private readonly statusBar: StatusBarPlugin) {}
+
   public register() {
     this.systemThemeQuery().addEventListener('change', () => {
       this.themeSubject.next(this.getTheme())
@@ -21,8 +25,14 @@ export class ThemeService {
     this.themeSubject.subscribe((theme) => {
       if (this.isDarkMode(theme)) {
         this.toggleDarkMode(true)
+
+        this.statusBar.setStyle({ style: Style.Dark })
+        this.statusBar.setBackgroundColor({ color: '#121212' })
         return
       }
+
+      this.statusBar.setStyle({ style: Style.Light })
+      this.statusBar.setBackgroundColor({ color: '#FFFFFF' })
 
       this.toggleDarkMode(false)
     })

--- a/src/app/services/appearance/theme.service.ts
+++ b/src/app/services/appearance/theme.service.ts
@@ -17,7 +17,6 @@ export class ThemeService {
 
   public register() {
     this.systemThemeQuery().addEventListener('change', () => {
-      console.log(this.getTheme())
       this.themeSubject.next(this.getTheme())
     })
 

--- a/src/app/services/appearance/theme.service.ts
+++ b/src/app/services/appearance/theme.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@angular/core'
+import { Subject } from 'rxjs'
+
+type themeOptions = 'light' | 'dark' | 'system'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ThemeService {
+  private readonly storageKey = 'theme'
+
+  public themeSubject: Subject<themeOptions> = new Subject()
+
+  public readonly supportsSystemPref = CSS.supports('color-scheme', 'dark')
+
+  constructor() {}
+
+  public register() {
+    this.systemThemeQuery().addEventListener('change', () => {
+      console.log(this.getTheme())
+      this.themeSubject.next(this.getTheme())
+    })
+
+    this.themeSubject.subscribe((value: themeOptions) => {
+      switch (value) {
+        case 'light':
+          this.toggleDarkMode(false)
+          return
+        case 'dark':
+          this.toggleDarkMode(true)
+          return
+        default:
+          this.toggleDarkMode(this.systemThemeQuery().matches ? true : false)
+          return
+      }
+    })
+
+    this.themeSubject.next(this.getTheme())
+  }
+
+  public toggleDarkMode(enabled: boolean): void {
+    document.body.classList.toggle('dark', enabled)
+  }
+
+  public setStorageItem(pref: themeOptions): void {
+    localStorage.setItem(this.storageKey, pref)
+  }
+
+  public getTheme(): themeOptions {
+    const storageItem: any = localStorage.getItem(this.storageKey)
+
+    if (storageItem == null) {
+      return this.fallBackTheme()
+    }
+
+    return storageItem
+  }
+
+  public systemThemeQuery(): MediaQueryList {
+    return window.matchMedia('(prefers-color-scheme: dark)')
+  }
+
+  private fallBackTheme(): themeOptions {
+    return this.supportsSystemPref ? 'system' : 'light'
+  }
+}

--- a/src/app/services/storage/storage.ts
+++ b/src/app/services/storage/storage.ts
@@ -9,6 +9,8 @@ import { SerializedAirGapMarketWalletGroup } from '../../models/AirGapMarketWall
 import { ExchangeTransactionDetails } from '../exchange/exchange'
 
 export type BeaconRequest = [string, any, ICoinProtocol]
+export type themeOptions = 'light' | 'dark' | 'system'
+
 export interface SerializedBeaconRequest {
   messageId: string
   payload: any
@@ -30,7 +32,8 @@ export enum WalletStorageKey {
   PENDING_EXCHANGE_TRANSACTIONS = 'PENDING_EXCHANGE_TRANSACTIONS',
   BEACON_REQUESTS = 'BEACON_REQUESTS',
   PENDING_REQUEST = 'PENDING_REQUEST',
-  GENERIC_SUBPROTOCOLS = 'GENERIC_SUBPROTOCOLS'
+  GENERIC_SUBPROTOCOLS = 'GENERIC_SUBPROTOCOLS',
+  THEME = 'theme'
 }
 
 interface IBroadcastTransaction {
@@ -54,6 +57,7 @@ interface WalletStorageKeyReturnType {
   [WalletStorageKey.BEACON_REQUESTS]: SerializedBeaconRequest[]
   [WalletStorageKey.PENDING_REQUEST]: SerializedBeaconRequest[]
   [WalletStorageKey.GENERIC_SUBPROTOCOLS]: Record<string, ProtocolOptions>
+  [WalletStorageKey.THEME]: themeOptions
 }
 
 type WalletStorageKeyReturnDefaults = { [key in WalletStorageKey]: WalletStorageKeyReturnType[key] }
@@ -72,7 +76,8 @@ const defaultValues: WalletStorageKeyReturnDefaults = {
   [WalletStorageKey.PENDING_EXCHANGE_TRANSACTIONS]: [],
   [WalletStorageKey.BEACON_REQUESTS]: [],
   [WalletStorageKey.PENDING_REQUEST]: [],
-  [WalletStorageKey.GENERIC_SUBPROTOCOLS]: {}
+  [WalletStorageKey.GENERIC_SUBPROTOCOLS]: {},
+  [WalletStorageKey.THEME]: undefined
 }
 
 @Injectable({

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -130,6 +130,11 @@
     "title": "Settings",
     "appearance_label": "Appearance",
     "theme_label": "Theme",
+    "select-theme": {
+      "system": "Device Theme",
+      "light": "Light Theme",
+      "dark": "Dark Theme"
+    },
     "help_label": "Help & Support",
     "introduction_label": "Introduction",
     "faq_label": "FAQ",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -128,6 +128,8 @@
   },
   "settings": {
     "title": "Settings",
+    "appearance_label": "Appearance",
+    "theme_label": "Theme",
     "help_label": "Help & Support",
     "introduction_label": "Introduction",
     "faq_label": "FAQ",
@@ -275,7 +277,7 @@
     "description":"You can always change your preference in the Settings Tab",
     "button_text": "Edit"
   },
-  
+
   "interaction-selection-desktop": {
     "title": "Select Signer Option",
     "heading": "Select the device to sign this transaction",
@@ -830,15 +832,15 @@
     "remove-all_label": "Remove All",
     "delete_label": "Delete",
     "no-peers": "Not connected to any peers",
-    "reset": "Reset", 
+    "reset": "Reset",
     "alert": {
       "heading": "Remove All",
       "message": "Are you sure you want to remove all peers?",
-      "cancel" : "Cancel", 
+      "cancel" : "Cancel",
       "confirm": "Confirm"
     }
   },
-  
+
   "walletconnect": {
     "connection_request": "WalletConnect - Connection Request",
     "new_transaction": "WalletConnect - New Transaction",
@@ -856,7 +858,7 @@
     "connection_error": "There was an issue connecting to WalletConnect"
   },
   "health-check": {
-    "title": "Health Check", 
+    "title": "Health Check",
     "message": "Checking API Health"
   },
   "group-label": {

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -186,6 +186,164 @@
   --ion-color-tint: #78c288;
 }
 
+/*
+ * Dark Colors
+ * Refer to https://ionicframework.com/docs/theming/dark-mode#ionic-dark-theme
+ * -------------------------------------------
+ */
+
+body.dark {
+  --ion-color-primary: #428cff;
+  --ion-color-primary-rgb: 66, 140, 255;
+  --ion-color-primary-contrast: #ffffff;
+  --ion-color-primary-contrast-rgb: 255, 255, 255;
+  --ion-color-primary-shade: #3a7be0;
+  --ion-color-primary-tint: #5598ff;
+
+  --ion-color-secondary: #50c8ff;
+  --ion-color-secondary-rgb: 80, 200, 255;
+  --ion-color-secondary-contrast: #ffffff;
+  --ion-color-secondary-contrast-rgb: 255, 255, 255;
+  --ion-color-secondary-shade: #46b0e0;
+  --ion-color-secondary-tint: #62ceff;
+
+  --ion-color-tertiary: #6a64ff;
+  --ion-color-tertiary-rgb: 106, 100, 255;
+  --ion-color-tertiary-contrast: #ffffff;
+  --ion-color-tertiary-contrast-rgb: 255, 255, 255;
+  --ion-color-tertiary-shade: #5d58e0;
+  --ion-color-tertiary-tint: #7974ff;
+
+  --ion-color-success: #2fdf75;
+  --ion-color-success-rgb: 47, 223, 117;
+  --ion-color-success-contrast: #000000;
+  --ion-color-success-contrast-rgb: 0, 0, 0;
+  --ion-color-success-shade: #29c467;
+  --ion-color-success-tint: #44e283;
+
+  --ion-color-warning: #ffd534;
+  --ion-color-warning-rgb: 255, 213, 52;
+  --ion-color-warning-contrast: #000000;
+  --ion-color-warning-contrast-rgb: 0, 0, 0;
+  --ion-color-warning-shade: #e0bb2e;
+  --ion-color-warning-tint: #ffd948;
+
+  --ion-color-danger: #ff4961;
+  --ion-color-danger-rgb: 255, 73, 97;
+  --ion-color-danger-contrast: #ffffff;
+  --ion-color-danger-contrast-rgb: 255, 255, 255;
+  --ion-color-danger-shade: #e04055;
+  --ion-color-danger-tint: #ff5b71;
+
+  --ion-color-dark: #f4f5f8;
+  --ion-color-dark-rgb: 244, 245, 248;
+  --ion-color-dark-contrast: #000000;
+  --ion-color-dark-contrast-rgb: 0, 0, 0;
+  --ion-color-dark-shade: #d7d8da;
+  --ion-color-dark-tint: #f5f6f9;
+
+  --ion-color-medium: #989aa2;
+  --ion-color-medium-rgb: 152, 154, 162;
+  --ion-color-medium-contrast: #000000;
+  --ion-color-medium-contrast-rgb: 0, 0, 0;
+  --ion-color-medium-shade: #86888f;
+  --ion-color-medium-tint: #a2a4ab;
+
+  --ion-color-light: #222428;
+  --ion-color-light-rgb: 34, 36, 40;
+  --ion-color-light-contrast: #ffffff;
+  --ion-color-light-contrast-rgb: 255, 255, 255;
+  --ion-color-light-shade: #1e2023;
+  --ion-color-light-tint: #383a3e;
+}
+
+/*
+ * iOS Dark Theme
+ * -------------------------------------------
+ */
+
+.ios body.dark {
+  --ion-background-color: #000000;
+  --ion-background-color-rgb: 0, 0, 0;
+
+  --ion-text-color: #ffffff;
+  --ion-text-color-rgb: 255, 255, 255;
+
+  --ion-color-step-50: #0d0d0d;
+  --ion-color-step-100: #1a1a1a;
+  --ion-color-step-150: #262626;
+  --ion-color-step-200: #333333;
+  --ion-color-step-250: #404040;
+  --ion-color-step-300: #4d4d4d;
+  --ion-color-step-350: #595959;
+  --ion-color-step-400: #666666;
+  --ion-color-step-450: #737373;
+  --ion-color-step-500: #808080;
+  --ion-color-step-550: #8c8c8c;
+  --ion-color-step-600: #999999;
+  --ion-color-step-650: #a6a6a6;
+  --ion-color-step-700: #b3b3b3;
+  --ion-color-step-750: #bfbfbf;
+  --ion-color-step-800: #cccccc;
+  --ion-color-step-850: #d9d9d9;
+  --ion-color-step-900: #e6e6e6;
+  --ion-color-step-950: #f2f2f2;
+
+  --ion-item-background: #000000;
+
+  --ion-card-background: #1c1c1d;
+}
+
+.ios body.dark ion-modal {
+  --ion-background-color: var(--ion-color-step-100);
+  --ion-toolbar-background: var(--ion-color-step-150);
+  --ion-toolbar-border-color: var(--ion-color-step-250);
+  --ion-item-background: var(--ion-color-step-150);
+}
+
+/*
+ * Material Design Dark Theme
+ * -------------------------------------------
+ */
+
+.md body.dark {
+  --ion-background-color: #121212;
+  --ion-background-color-rgb: 18, 18, 18;
+
+  --ion-text-color: #ffffff;
+  --ion-text-color-rgb: 255, 255, 255;
+
+  --ion-border-color: #222222;
+
+  --ion-color-step-50: #1e1e1e;
+  --ion-color-step-100: #2a2a2a;
+  --ion-color-step-150: #363636;
+  --ion-color-step-200: #414141;
+  --ion-color-step-250: #4d4d4d;
+  --ion-color-step-300: #595959;
+  --ion-color-step-350: #656565;
+  --ion-color-step-400: #717171;
+  --ion-color-step-450: #7d7d7d;
+  --ion-color-step-500: #898989;
+  --ion-color-step-550: #949494;
+  --ion-color-step-600: #a0a0a0;
+  --ion-color-step-650: #acacac;
+  --ion-color-step-700: #b8b8b8;
+  --ion-color-step-750: #c4c4c4;
+  --ion-color-step-800: #d0d0d0;
+  --ion-color-step-850: #dbdbdb;
+  --ion-color-step-900: #e7e7e7;
+  --ion-color-step-950: #f3f3f3;
+
+  --ion-item-background: #1e1e1e;
+
+  --ion-toolbar-background: #1f1f1f;
+
+  --ion-tab-bar-background: #1f1f1f;
+
+  --ion-card-background: #1e1e1e;
+}
+
 ion-avatar {
   min-width: 48px;
   min-height: 48px;


### PR DESCRIPTION
Closes #38.

Provides a new service, and allows the selection of three themes
1. Device
2. Light
3. Dark

Stored in local storage.
Device theme updates real time in-coordination with the system (only if supported).

What is missing / Needs to be addressed:
- [ ] The UI inconsistencies that appear on dark-mode
- [ ] iOS testing
- [ ] Change the default dark ionic-framework colors to align with brand colors
- [ ] There should be a dark version of the splash screen.
- [ ] Translation
- [ ] Refactoring? 

Adds a new package to fix a bug with capacitorjs on android (https://github.com/ionic-team/capacitor/discussions/1978):
https://github.com/robingenz/capacitor-android-dark-mode-support
_Simple fix, could be implemented into the source code instead of relying on the package_

Tested on android & the browser

Side note: First time touching the tech used in the wallet, apologies from now for any bad practices 😅
